### PR TITLE
/plants route fixed on home page

### DIFF
--- a/src/Pages/Home.jsx
+++ b/src/Pages/Home.jsx
@@ -39,7 +39,7 @@ const Home = () => {
           whileTap={{ scale: 0.95 }}
         >
           <Link
-            to="/plant"
+            to="/plants"
             className="w-full h-full bg-transparent border-none cursor-pointer"
           >
             Find Your Plant Now


### PR DESCRIPTION
At home page the route at "Find Your Plants" button is wrong, it should be /plants instead of /plant, i had fixed it, please accept the pull request.