### PR TITLE
Fix UI/UX Issues Across Forms, Footer, FAQ, and Plant Page – Closes #73

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "jodit": "^4.2.27",
         "jodit-react": "^4.1.2",
         "lottie-react": "^2.4.0",
+        "lucide-react": "^0.525.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hot-toast": "^2.4.1",
@@ -3831,6 +3832,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.27.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "jodit": "^4.2.27",
     "jodit-react": "^4.1.2",
     "lottie-react": "^2.4.0",
+    "lucide-react": "^0.525.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.4.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,7 +29,7 @@ const App = () => {
       </header>
 
       {/* Main content area with padding */}
-      <main className="flex-grow pt-16">
+      <main className="flex-grow pt-14">
         <Routes>
           <Route path="/" element={<HeroSection />} />
           <Route path="write-blog" element={<CreateBlog />} />

--- a/src/Component/Auth/Loginform.jsx
+++ b/src/Component/Auth/Loginform.jsx
@@ -1,84 +1,77 @@
 import React, { useState } from "react";
 import { toast } from "react-hot-toast";
-import { signin, signUp } from "../../service/oprations/authApi";
+import { signin } from "../../service/oprations/authApi";
 import { useNavigate } from "react-router-dom";
 import { useDispatch } from "react-redux";
-import { setLoading } from "../../slices/Auth";
 
 const Logingform = () => {
   const [formData, setFormData] = useState({
     email: "",
-
     password: "",
   });
 
-  const handleChange = (e) => {
+  const handleChange = (e) =>
     setFormData({ ...formData, [e.target.name]: e.target.value });
-  };
 
   const navigate = useNavigate();
   const dispatch = useDispatch();
 
   const onSubmithandle = async (e) => {
     e.preventDefault();
-
     const { email, password } = formData;
 
-    // Basic validation
     if (!email || !password) {
       return toast.error("All fields are required");
     }
 
     try {
-      // Dispatch the signUp action and handle navigation within it
       dispatch(signin(email, password, navigate));
     } catch (error) {
-      console.error("Signup error:", error);
-      toast.error("An error occurred during signup");
+      console.error("Login error:", error);
+      toast.error("An error occurred during login");
     }
   };
 
   return (
-    <div className=" flex  ">
-      <div className="  poppins-regular  w-full focus:outline outline-[1px] p-8 ">
-        {" "}
-        <form
-          className="flex  flex-col gap-5 items-center"
-          onSubmit={onSubmithandle}
-        >
-          <label className="w-full">
-            <p className="text-[15px] mb-2">Email:</p>
-            <input
-              className="input-shadow p-2   w-full rounded-md bg-green-300/10 focus:outline-green-800 focus:outline focus:outline-2"
-              type="email"
-              placeholder="@email"
-              name="email"
-              onChange={handleChange}
-              value={formData.email}
-            />
-          </label>
-
-          <label className="w-full">
-            <p className="text-[15px] mb-2">Password:</p>
-            <input
-              className="input-shadow p-2 focus:outline-green-800 focus:outline focus:outline-2 w-full rounded-md bg-green-300/10"
-              type="password"
-              name="password"
-              placeholder="@password"
-              onChange={handleChange}
-              value={formData.password}
-            />
-          </label>
-
-          <button
-            className="bg-green-300 p-2 mt-3 rounded-md input-shadow items-center"
-            type="submit"
-          >
-            Sign In
-          </button>
-        </form>
+    <form
+      className="flex flex-col gap-5 items-center w-full"
+      onSubmit={onSubmithandle}
+    >
+      <div className="w-full">
+        <label className="block text-sm font-medium text-green-800 mb-1">
+          Email
+        </label>
+        <input
+          className="w-full rounded-md p-2 bg-white border border-green-300 input-shadow focus:outline-none focus:ring-2 focus:ring-green-400"
+          type="email"
+          placeholder="you@example.com"
+          name="email"
+          onChange={handleChange}
+          value={formData.email}
+        />
       </div>
-    </div>
+
+      <div className="w-full">
+        <label className="block text-sm font-medium text-green-800 mb-1">
+          Password
+        </label>
+        <input
+          className="w-full rounded-md p-2 bg-white border border-green-300 input-shadow focus:outline-none focus:ring-2 focus:ring-green-400"
+          type="password"
+          name="password"
+          placeholder="••••••••"
+          onChange={handleChange}
+          value={formData.password}
+        />
+      </div>
+
+      <button
+        type="submit"
+        className="w-full bg-green-300 text-green-900 font-semibold p-2 rounded-md input-shadow hover:bg-green-400 transition"
+      >
+        Sign In
+      </button>
+    </form>
   );
 };
 

--- a/src/Component/Auth/Signupform.jsx
+++ b/src/Component/Auth/Signupform.jsx
@@ -3,7 +3,6 @@ import { toast } from "react-hot-toast";
 import { signUp } from "../../service/oprations/authApi";
 import { useNavigate } from "react-router-dom";
 import { useDispatch } from "react-redux";
-import { setLoading } from "../../slices/Auth";
 
 const Signupform = () => {
   const [formData, setFormData] = useState({
@@ -12,25 +11,21 @@ const Signupform = () => {
     password: "",
   });
 
-  const handleChange = (e) => {
+  const handleChange = (e) =>
     setFormData({ ...formData, [e.target.name]: e.target.value });
-  };
 
   const navigate = useNavigate();
   const dispatch = useDispatch();
 
   const onSubmithandle = async (e) => {
     e.preventDefault();
-
     const { email, username, password } = formData;
 
-    // Basic validation
     if (!email || !username || !password) {
       return toast.error("All fields are required");
     }
 
     try {
-      // Dispatch the signUp action and handle navigation within it
       dispatch(signUp(username, email, password, navigate));
     } catch (error) {
       console.error("Signup error:", error);
@@ -39,58 +34,56 @@ const Signupform = () => {
   };
 
   return (
-    <div className=" flex  ">
-      <div className="  poppins-regular  w-full focus:outline outline-[1px] p-8 ">
-        {" "}
-        <form
-          className="flex  flex-col gap-5 items-center"
-          onSubmit={onSubmithandle}
-        >
-          <label className="w-full">
-            <p className="text-[15px] mb-2">Email:</p>
-            <input
-              className="input-shadow p-2   w-full rounded-md bg-green-300/10 focus:outline-green-800 focus:outline focus:outline-2"
-              type="email"
-              placeholder="@email"
-              name="email"
-              onChange={handleChange}
-              value={formData.email}
-            />
-          </label>
-
-          <label className="w-full">
-            <p className="text-[15px] mb-2">Username:</p>
-            <input
-              className="input-shadow p-2 w-full focus:outline-green-800 focus:outline focus:outline-2 rounded-md bg-green-300/10"
-              type="text"
-              placeholder="@username"
-              name="username"
-              onChange={handleChange}
-              value={formData.username}
-            />
-          </label>
-
-          <label className="w-full">
-            <p className="text-[15px] mb-2">Password:</p>
-            <input
-              className="input-shadow p-2 focus:outline-green-800 focus:outline focus:outline-2 w-full rounded-md bg-green-300/10"
-              type="password"
-              name="password"
-              placeholder="@password"
-              onChange={handleChange}
-              value={formData.password}
-            />
-          </label>
-
-          <button
-            className="bg-green-300 p-2 mt-3 rounded-md input-shadow items-center"
-            type="submit"
-          >
-            Signup
-          </button>
-        </form>
+    <form className="space-y-5 w-full" onSubmit={onSubmithandle}>
+      <div>
+        <label className="block text-sm font-medium text-green-800 mb-1">
+          Email
+        </label>
+        <input
+          className="w-full rounded-md p-2 bg-white border border-green-300 input-shadow focus:outline-none focus:ring-2 focus:ring-green-400"
+          type="email"
+          name="email"
+          placeholder="you@example.com"
+          value={formData.email}
+          onChange={handleChange}
+        />
       </div>
-    </div>
+
+      <div>
+        <label className="block text-sm font-medium text-green-800 mb-1">
+          Username
+        </label>
+        <input
+          className="w-full rounded-md p-2 bg-white border border-green-300 input-shadow focus:outline-none focus:ring-2 focus:ring-green-400"
+          type="text"
+          name="username"
+          placeholder="your_username"
+          value={formData.username}
+          onChange={handleChange}
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-green-800 mb-1">
+          Password
+        </label>
+        <input
+          className="w-full rounded-md p-2 bg-white border border-green-300 input-shadow focus:outline-none focus:ring-2 focus:ring-green-400"
+          type="password"
+          name="password"
+          placeholder="••••••••"
+          value={formData.password}
+          onChange={handleChange}
+        />
+      </div>
+
+      <button
+        type="submit"
+        className="w-full bg-green-300 text-green-900 font-semibold p-2 rounded-md input-shadow hover:bg-green-400 transition"
+      >
+        Signup
+      </button>
+    </form>
   );
 };
 

--- a/src/Component/Faq.jsx
+++ b/src/Component/Faq.jsx
@@ -30,52 +30,53 @@ const faq = [
 ];
 
 const Faq = () => {
-  const [visibleIndex, setVisibleIndex] = useState(null);
+  const [activeIndex, setActiveIndex] = useState(null);
 
-  // Toggle visibility function
-  const handleToggle = (index) => {
-    setVisibleIndex(visibleIndex === index ? null : index);
+  const toggleQuestion = (index) => {
+    setActiveIndex((prev) => (prev === index ? null : index));
   };
 
   return (
-    <div className="mt-10">
-      <h1 className="text-center m-8 text-4xl poppins-bold text-black/80">
-        {" "}
-        FAQ'S
-      </h1>
+    <section className="py-12 bg-white">
+      <h2 className="text-center text-4xl font-bold text-green-800 mb-10">
+        FAQs
+      </h2>
       <div className="flex flex-col gap-5 items-center">
-        {faq.map((qa, index) => (
-          <div
-            key={index}
-            className="border-2 p-3 w-[60%] rounded-xl border-green-300"
-          >
-            <div>
-              <div className="flex justify-between items-center">
-                <h1 className="text-xl poppins-semibold text-black/80">
-                  {qa.question}
-                </h1>
-                <div
-                  className="text-xl text-green-400 cursor-pointer"
-                  onClick={() => handleToggle(index)}
-                >
-                  {visibleIndex === index ? (
-                    <FaMinusCircle />
-                  ) : (
-                    <FaPlusCircle />
-                  )}
-                </div>
-              </div>
+        {faq.map((item, index) => {
+          const isActive = index === activeIndex;
 
-              {visibleIndex === index && (
-                <p className="poppins-semibold text-black/50 mt-2">
-                  {qa.answer}
+          return (
+            <div
+              key={index}
+              className="w-[90%] md:w-[60%] border border-green-300 rounded-xl p-4 bg-green-50 shadow-md transition-all duration-300"
+            >
+              <button
+                className="flex justify-between items-center w-full text-left"
+                onClick={() => toggleQuestion(index)}
+                aria-expanded={isActive}
+              >
+                <span className="text-lg font-medium text-green-800">
+                  {item.question}
+                </span>
+                <span className="text-green-500 text-xl">
+                  {isActive ? <FaMinusCircle /> : <FaPlusCircle />}
+                </span>
+              </button>
+
+              <div
+                className={`overflow-hidden transition-all duration-300 ${
+                  isActive ? "max-h-96 mt-3" : "max-h-0"
+                }`}
+              >
+                <p className="text-gray-700 leading-relaxed">
+                  {item.answer}
                 </p>
-              )}
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/src/Component/FeatureCard.jsx
+++ b/src/Component/FeatureCard.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 const FeatureCard = ({ icon, heading, description, path }) => {
   return (
-    <div className="border-2 p-4 lg:w-[480px]   border-green-300 rounded-xl m-5 cursor-pointer">
+    <div className="border-2 p-4 lg:w-[480px] border-green-300 hover:bg-green-50 transition-all hover:scale-105 duration-300 rounded-xl m-5 cursor-pointer">
       <Link to={`${path}`}>
         {" "}
         <div className="flex items-center gap-3">

--- a/src/Component/Footer.jsx
+++ b/src/Component/Footer.jsx
@@ -60,7 +60,7 @@ const Footer = () => {
   ];
 
   return (
-    <footer className="bg-gradient-to-r from-green-200/30 via-green-100/30 to-green-200/30 text-gray-700 pt-14 pb-8 mt-12">
+    <footer className="bg-gradient-to-r from-green-200/30 via-green-100/30 to-green-200/30 text-gray-700 pt-14 pb-8">
       <div className="max-w-6xl mx-auto px-6">
         {/* Main grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-10 mb-10">

--- a/src/Component/Footer.jsx
+++ b/src/Component/Footer.jsx
@@ -1,97 +1,133 @@
-import React from "react";
+import {
+  Facebook,
+  Twitter,
+  Instagram,
+  Linkedin,
+  Leaf,
+  BookOpen,
+  Mail,
+  Smile,
+  Heart,
+} from "lucide-react";
 import { Link } from "react-router-dom";
 import logo from "../assets/lungs-leaf-nature-ecology-logo-free-vector-removebg-preview.png";
-import {
-  FaFacebookF,
-  FaTwitter,
-  FaInstagram,
-  FaLinkedinIn,
-} from "react-icons/fa"; // Importing icons
 
 const Footer = () => {
+  const currentYear = new Date().getFullYear();
+
+  const socialLinks = [
+    { name: "Facebook", icon: Facebook },
+    { name: "Twitter", icon: Twitter },
+    { name: "Instagram", icon: Instagram },
+    { name: "LinkedIn", icon: Linkedin },
+  ];
+
+  const footerLinks = [
+    {
+      title: "Quick Links",
+      links: [
+        {
+          name: "Plants",
+          href: "/plants",
+          icon: Leaf,
+          color: "text-green-500",
+        },
+        {
+          name: "Blogs",
+          href: "/blogs",
+          icon: BookOpen,
+          color: "text-yellow-500",
+        },
+      ],
+    },
+    {
+      title: "More",
+      links: [
+        {
+          name: "Contact Us",
+          href: "/contact",
+          icon: Mail,
+          color: "text-blue-500",
+        },
+        {
+          name: "About",
+          href: "/about",
+          icon: Smile,
+          color: "text-pink-500",
+        },
+      ],
+    },
+  ];
+
   return (
-    <footer className="bg-gradient-to-r from-green-400/40 via-green-300/40 to-green-400/40 poppins-regular  text-black/80 py-10 mt-12">
-      <div className="container mx-auto flex flex-col lg:flex-row justify-between items-center px-6">
-        {/* Logo and Brand */}
-        <div className="flex items-center mb-6 lg:mb-0">
-          <img className="h-16 mr-3" src={logo} alt="Clean Breath Logo" />
-          <h1 className="text-3xl font-bold poppins-bold">
-            Clean <br /> Breath
-          </h1>
+    <footer className="bg-gradient-to-r from-green-200/30 via-green-100/30 to-green-200/30 text-gray-700 pt-14 pb-8 mt-12">
+      <div className="max-w-6xl mx-auto px-6">
+        {/* Main grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-10 mb-10">
+          {/* Brand Section */}
+          <div className="lg:col-span-2 flex flex-col">
+            <div className="flex items-center gap-3 mb-3">
+              <img src={logo} alt="Clean Breath Logo" className="w-12 h-12" />
+              <h2 className="text-2xl sm:text-3xl font-bold bg-gradient-to-r from-green-600 to-emerald-500 bg-clip-text text-transparent">
+                Clean Breath
+              </h2>
+            </div>
+            <p className="text-sm text-gray-600 max-w-md leading-relaxed">
+              Discover plants that purify your air and create a healthier environment. Search by air quality needs to find the perfect plant that not only enhances your space but also boosts your well-being.
+            </p>
+            <div className="flex space-x-4 mt-6">
+              {socialLinks.map((social) => (
+                <a
+                  key={social.name}
+                  href="#"
+                  className="text-gray-500 hover:text-green-600 transition-colors duration-200"
+                >
+                  <social.icon className="w-5 h-5 sm:w-6 sm:h-6" />
+                </a>
+              ))}
+            </div>
+          </div>
+
+          {/* Footer Links Sections */}
+          {footerLinks.map((section) => (
+            <div key={section.title}>
+              <h3 className="text-gray-800 font-semibold mb-4">{section.title}</h3>
+              <ul className="space-y-3">
+                {section.links.map((link) => (
+                  <li key={link.name}>
+                    <Link
+                      to={link.href}
+                      className="flex items-center gap-2 text-gray-600 hover:text-gray-900 transition-all"
+                    >
+                      <link.icon className={`w-4 h-4 ${link.color}`} />
+                      <span>{link.name}</span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
         </div>
 
-        {/* Navigation Links */}
-        <nav className="mb-6 lg:mb-0">
-          <ul className="flex flex-col lg:flex-row lg:space-x-8 space-y-4 lg:space-y-0 text-lg">
-            <li>
-              <Link
-                to="/"
-                className="hover:text-gray-100 hover:scale-105 transition duration-300"
+        {/* Bottom Section */}
+        <div className="border-t border-gray-200 pt-6 mt-6 flex flex-col md:flex-row justify-between items-center gap-4 text-sm text-gray-500">
+          <p>© {currentYear} Clean Breath. All rights reserved.</p>
+          <div className="flex items-center gap-1">
+            <span>Made with</span>
+            <Heart className="w-4 h-4 text-red-500" />
+            <span>
+              by{" "}
+              <a
+                href="https://github.com/chandannekya/Clean-Breath"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-500 hover:text-blue-600 transition-colors"
               >
-                Home
-              </Link>
-            </li>
-            <li>
-              <Link
-                to="/about"
-                className="hover:text-gray-100 hover:scale-105 transition duration-300"
-              >
-                About
-              </Link>
-            </li>
-            <li>
-              <Link
-                to="/services"
-                className="hover:text-gray-100 hover:scale-105 transition duration-300"
-              >
-                Services
-              </Link>
-            </li>
-            <li>
-              <Link
-                to="/contact"
-                className="hover:text-gray-100 hover:scale-105 transition duration-300"
-              >
-                Contact
-              </Link>
-            </li>
-          </ul>
-        </nav>
-
-        {/* Social Media Links */}
-        <div className="flex space-x-6">
-          <a
-            href="#"
-            className="hover:text-gray-100 hover:scale-110 transition duration-300"
-          >
-            <FaFacebookF className="w-6 h-6" />
-          </a>
-          <a
-            href="#"
-            className="hover:text-gray-100 hover:scale-110 transition duration-300"
-          >
-            <FaTwitter className="w-6 h-6" />
-          </a>
-          <a
-            href="#"
-            className="hover:text-gray-100 hover:scale-110 transition duration-300"
-          >
-            <FaInstagram className="w-6 h-6" />
-          </a>
-          <a
-            href="#"
-            className="hover:text-gray-100 hover:scale-110 transition duration-300"
-          >
-            <FaLinkedinIn className="w-6 h-6" />
-          </a>
+                Chandan
+              </a>
+            </span>
+          </div>
         </div>
-      </div>
-
-      {/* Bottom Text */}
-      <div className="text-center mt-8">
-        <p className="text-sm">
-          &copy; 2024 Clean Breath. All rights reserved.
-        </p>
       </div>
     </footer>
   );

--- a/src/Component/PlantCard.jsx
+++ b/src/Component/PlantCard.jsx
@@ -47,7 +47,7 @@ const PlantCard = ({ plantName, plantDetails }) => {
           </div>
           <Link
             to={`/plant/${encodeURIComponent(plantName)}`}
-            className="bg-green-300 rounded-md flex p-2 items-center m-4 text-white/70 hover:scale-105 transition-all duration-300 ease-in-out  poppins-regular"
+            className="bg-green-500 rounded-md flex p-2 items-center m-4 text-white/70 hover:scale-105 transition-all duration-300 ease-in-out  poppins-regular"
           >
             Know More
           </Link>

--- a/src/Pages/AboutUs.jsx
+++ b/src/Pages/AboutUs.jsx
@@ -1,118 +1,114 @@
 import React from "react";
 import { FaLeaf, FaGlobeAmericas, FaSeedling } from "react-icons/fa";
 
-
 const AboutUs = () => {
   return (
-    <div className="bg-gray-100 text-gray-800">
+    <div className="bg-white text-gray-800">
       {/* Header */}
-      <header className="bg-green-100 shadow p-6 text-center">
+      <header className="p-8 text-center">
         <h1 className="text-4xl font-bold text-green-700">About Clean Breath</h1>
         <p className="mt-2 text-lg text-gray-700">Breathing clean, living green 🌱</p>
       </header>
 
-      {/* About Section */}
-      <section className="max-w-6xl mx-auto px-6 py-10">
-        <div className="grid md:grid-cols-2 gap-8 items-center">
+      {/* Who We Are */}
+      <section className="max-w-6xl mx-auto px-6 py-16">
+        <div className="grid md:grid-cols-2 gap-10 items-center">
           <div>
             <h2 className="text-3xl font-bold text-green-800 mb-4">Who We Are</h2>
-            <p className="text-gray-700 mb-4">
+            <p className="text-gray-700 mb-4 leading-relaxed">
               <strong>Clean Breath</strong> is a smart web application built with a purpose – to improve the air quality around you through the power of plants.
-              Our platform uses data-driven insights to recommend the best plants for reducing harmful pollutants like SO2, PM10, NO2, CO, O3, and PM2.5.
+              Our platform uses data-driven insights to recommend the best plants for reducing harmful pollutants like SO₂, PM10, NO₂, CO, O₃, and PM2.5.
             </p>
-            <p className="text-gray-700 mb-4">
+            <p className="text-gray-700 mb-6 leading-relaxed">
               By integrating science, sustainability, and technology, we aim to empower individuals, families, and communities to make informed choices for a healthier environment—both indoors and outdoors.
             </p>
             <a
               href="/plants"
-              className="inline-block mt-4 bg-green-600 text-white px-5 py-2 rounded-lg hover:bg-green-700 transition"
+              className="inline-block bg-green-600 text-white px-6 py-3 rounded-md hover:bg-green-700 transition"
             >
-              Explore Plants
+              🌿 Explore Plants
             </a>
           </div>
           <div>
             <img
               src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR7gU1Q-A0Ds80g38j4C5tmr8OQP7nbblwEXA&s"
               alt="Green Plant"
-              className="w-full rounded-lg shadow-md"
+              className="w-full rounded-lg shadow-md max-h-[400px] object-cover"
             />
           </div>
         </div>
       </section>
 
       {/* Our Mission */}
-      <section className="bg-white py-12">
-        <div className="max-w-6xl mx-auto px-6 text-center">
+      <section className="bg-gray-50 py-16">
+        <div className="max-w-4xl mx-auto px-6 text-center">
           <h2 className="text-3xl font-bold text-green-800 mb-6">Our Mission 🌍</h2>
-          <p className="text-lg text-gray-700 mb-6">
+          <p className="text-lg text-gray-700 mb-4">
             Our mission is simple yet powerful:
-            <br />
-            <strong className="text-green-600">
-              To create cleaner air and healthier lives—one plant at a time.
-            </strong>
           </p>
-          <p className="text-gray-600">
-            We believe every home, office, and public space deserves fresh air. Through real-time data and plant recommendations,
+          <p className="text-green-600 font-semibold text-xl mb-6">
+            To create cleaner air and healthier lives—one plant at a time.
+          </p>
+          <p className="text-gray-600 leading-relaxed">
+            We believe every home, office, and public space deserves fresh air.
+            Through real-time data and plant recommendations,
             we’re building a greener, cleaner future that starts with you.
           </p>
         </div>
       </section>
 
       {/* Community and Sustainability */}
-      <section className="py-12 bg-gray-50">
-        <div className="max-w-6xl mx-auto px-6">
-          <div className="grid md:grid-cols-2 gap-8 items-center">
+      <section className="py-16 bg-white">
+        <div className="max-w-6xl mx-auto px-6 grid md:grid-cols-2 gap-10 items-center">
+          <div>
             <img
               src="https://media.istockphoto.com/id/1380361370/photo/decorative-banana-plant-in-concrete-vase-isolated-on-white-background.jpg?s=612x612&w=0&k=20&c=eYADMQ9dXTz1mggdfn_exN2gY61aH4fJz1lfMomv6o4="
-              alt="People Planting Trees"
-              className="rounded-lg shadow-md"
+              alt="Plant Decor"
+              className="w-full rounded-lg shadow-md max-h-[400px] object-cover"
             />
-            <div>
-              <h3 className="text-2xl font-semibold text-green-700 mb-3">
-                Community and Sustainability
-              </h3>
-              <p className="text-gray-700">
-                Clean Breath isn't just a tool—it's a movement. We're committed to spreading awareness about indoor and outdoor air pollution and promoting sustainable living through the power of plants.
-                Together, we can make a difference—one plant, one home, one breath at a time.
-              </p>
-            </div>
+          </div>
+          <div>
+            <h3 className="text-2xl font-semibold text-green-700 mb-3">
+              Community and Sustainability
+            </h3>
+            <p className="text-gray-700 leading-relaxed">
+              Clean Breath isn't just a tool—it’s a movement. We're committed to spreading awareness about indoor and outdoor air pollution and promoting sustainable living through the power of plants.
+              Together, we can make a difference—one plant, one home, one breath at a time.
+            </p>
           </div>
         </div>
       </section>
 
-      {/* Join Our Community */}
-      <section className="bg-green-100 py-12">
+      {/* Join Community */}
+      <section className="bg-green-100 py-16">
         <div className="max-w-xl mx-auto px-6 text-center">
           <h2 className="text-3xl font-bold text-green-800 mb-6">Join Our Community 🌿</h2>
           <p className="text-gray-700 mb-6">
             Become part of our green family. Subscribe to receive the latest updates, plant care tips, and eco-living inspiration straight to your inbox!
           </p>
-          <form className="bg-white p-6 rounded-lg shadow-md space-y-4">
+          <form className="bg-white p-6 rounded-lg shadow space-y-4">
             <input
               type="text"
               placeholder="Your Name"
-              className="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400"
+              className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-400"
               required
             />
             <input
               type="email"
               placeholder="Your Email"
-              className="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400"
+              className="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-400"
               required
             />
             <button
               type="submit"
-              className="w-full bg-green-600 text-white py-2 rounded-lg hover:bg-green-700 transition"
+              className="w-full bg-green-600 text-white py-2 rounded-md hover:bg-green-700 transition"
             >
               Join Now
             </button>
           </form>
         </div>
       </section>
-      </div>
-
-      
-    
+    </div>
   );
 };
 

--- a/src/Pages/Feature.jsx
+++ b/src/Pages/Feature.jsx
@@ -4,8 +4,39 @@ import { GiConvergenceTarget } from "react-icons/gi";
 import { RiPlantFill } from "react-icons/ri";
 import { BiMessageSquareEdit } from "react-icons/bi";
 import { FaStore } from "react-icons/fa";
-import { Link } from "react-router-dom";
+
 const Feature = () => {
+  const features = [
+    {
+      icon: <GiConvergenceTarget />,
+      path: "/plant",
+      heading: "Track Air Quality",
+      description:
+        "Monitor real-time air quality data and pollutant concentrations to stay informed about your surroundings.",
+    },
+    {
+      icon: <RiPlantFill />,
+      path: "/plants",
+      heading: "Know Your Plant",
+      description:
+        "Learn about various plants and their benefits, from air purification to aesthetic appeal, and how they can enhance your indoor environment.",
+    },
+    {
+      icon: <BiMessageSquareEdit />,
+      path: "/blogs",
+      heading: "Green Insights",
+      description:
+        "Explore our blogs for insightful articles on plant care, benefits, and tips to create a greener, healthier living space.",
+    },
+    {
+      icon: <FaStore />,
+      path: "/store",
+      heading: "Find Your Plant",
+      description:
+        "Discover a wide variety of plants suited to different environments and preferences, and find the perfect addition to your space.",
+    },
+  ];
+
   return (
     <div className=" ">
       <h1 className="text-center text-5xl poppins-bold text-black/80 m-8">
@@ -22,42 +53,19 @@ const Feature = () => {
       </p>
 
       <div className="  flex flex-col items-center gap-4  m-7 ">
-        <div className="flex gap-4 lg:flex-row flex-col ">
-          <FeatureCard
-            icon={<GiConvergenceTarget />}
-            path={"/plant"}
-            heading={"Track Air Quality"}
-            description={
-              "Monitor real-time air quality data and pollutant concentrations to stay informed about your surroundings."
-            }
-          />
-          <FeatureCard
-            path={"/plants"}
-            icon={<RiPlantFill />}
-            heading={"Know Your Plant"}
-            description={
-              "Learn about various plants and their benefits, from air purification to aesthetic appeal, and how they can enhance your indoor environment."
-            }
-          />
-        </div>
-        <div className="flex gap-4 lg:flex-row flex-col">
-          <FeatureCard
-            path={"/blogs"}
-            icon={<BiMessageSquareEdit />}
-            heading={"Green Insights"}
-            description={
-              "Explore our blogs for insightful articles on plant care, benefits, and tips to create a greener, healthier living space."
-            }
-          />
-          <FeatureCard
-            icon={<FaStore />}
-            path={"/store"}
-            heading={"Find Your Plant"}
-            description={
-              "Discover a wide variety of plants suited to different environments and preferences, and find the perfect addition to your space."
-            }
-          />
-        </div>
+        {[0, 1].map((rowIndex) => (
+          <div key={rowIndex} className="flex gap-4 lg:flex-row flex-col ">
+            {features.slice(rowIndex * 2, rowIndex * 2 + 2).map((feature, i) => (
+              <FeatureCard
+                key={i}
+                icon={feature.icon}
+                path={feature.path}
+                heading={feature.heading}
+                description={feature.description}
+              />
+            ))}
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/Pages/HeroSection.jsx
+++ b/src/Pages/HeroSection.jsx
@@ -20,7 +20,7 @@ const HeroSection = () => {
       style={{
         scale: scale,
       }}
-      className="flex flex-col gap-4"
+      className="flex flex-col gap-4 mb-12"
     >
       <Home />
       <PlantSection />

--- a/src/Pages/Login.jsx
+++ b/src/Pages/Login.jsx
@@ -1,14 +1,15 @@
-import React from "react";
 import Logingform from "../Component/Auth/Loginform";
 
 const Login = () => {
   return (
-    <div className="  justify-center  flex flex-col items-center  ">
-      <div className="lg:w-[40%] bg-slate-800/10 m-8  border-2  border-green-950 rounded-md p-8">
-        {" "}
-        <h1 className="text-4xl text-black/85 mt-5 poppins-bold">
+    <div className="min-h-screen bg-white flex items-center justify-center px-4 py-12">
+      <div className="bg-green-50 border border-green-600 shadow-lg rounded-lg w-full max-w-xl p-8">
+        <h1 className="text-3xl font-bold text-green-800 mb-4">
           Welcome Back!
         </h1>
+        <p className="text-gray-700 text-sm mb-6">
+          Sign in to access your dashboard, track air quality, and find the perfect plant for a cleaner, healthier environment.
+        </p>
         <Logingform />
       </div>
     </div>

--- a/src/Pages/PlantDel.jsx
+++ b/src/Pages/PlantDel.jsx
@@ -43,12 +43,12 @@ const PlantDel = () => {
   ) : (
     <div>
       <div className="flex flex-col justify-around items-center gap-5">
-        <div className="border-2 flex  items-center  p-2 bg-transparent rounded-lg mt-5">
+        <div className="border-2 flex items-center gap-2 p-2 bg-transparent rounded-lg mt-5">
           {gases.map((gas) => (
             <div
               key={gas}
               className={`text-center poppins-regular text-black/80 cursor-pointer ${
-                selectedGas === gas ? "bg-green-300 rounded-md p-2" : ""
+                selectedGas === gas ? "bg-green-300 rounded-md scale-105" : "scale-100"
               }`}
               onClick={() => handleGasSelection(gas)}
             >

--- a/src/Pages/PlantDel.jsx
+++ b/src/Pages/PlantDel.jsx
@@ -32,8 +32,8 @@ const PlantDel = () => {
     selectedGas === "All"
       ? Object.entries(PlantDis)
       : Object.entries(PlantDis).filter(([key, plantDetails]) =>
-          plantDetails.gases.includes(selectedGas)
-        );
+        plantDetails.gases.includes(selectedGas)
+      );
 
   return loading ? (
     <div className=" h-screen flex justify-center items-center">
@@ -41,32 +41,29 @@ const PlantDel = () => {
       <Loader />
     </div>
   ) : (
-    <div>
-      <div className="flex flex-col justify-around items-center gap-5">
-        <div className="border-2 flex items-center gap-2 p-2 bg-transparent rounded-lg mt-5">
-          {gases.map((gas) => (
-            <div
-              key={gas}
-              className={`text-center poppins-regular text-black/80 cursor-pointer ${
-                selectedGas === gas ? "bg-green-300 rounded-md scale-105" : "scale-100"
+    <div className="flex flex-col justify-around items-center gap-5 mb-12">
+      <div className="border-2 flex items-center gap-2 p-2 bg-transparent rounded-lg mt-5">
+        {gases.map((gas) => (
+          <div
+            key={gas}
+            className={`text-center poppins-regular text-black/80 cursor-pointer ${selectedGas === gas ? "bg-green-300 rounded-md scale-105" : "scale-100"
               }`}
-              onClick={() => handleGasSelection(gas)}
-            >
-              <h1 className="p-2">{gas}</h1>
-            </div>
-          ))}
-        </div>
+            onClick={() => handleGasSelection(gas)}
+          >
+            <h1 className="p-2">{gas}</h1>
+          </div>
+        ))}
+      </div>
 
-        <div className="grid lg:grid-cols-3 md:grid-cols-2 gap-4">
-          {filteredPlants.map(([key, plantDetails]) => (
-            <div key={plantDetails._id}>
-              <PlantCard
-                plantName={plantDetails.name}
-                plantDetails={plantDetails.scientificName}
-              />
-            </div>
-          ))}
-        </div>
+      <div className="grid lg:grid-cols-3 md:grid-cols-2 gap-4">
+        {filteredPlants.map(([key, plantDetails]) => (
+          <div key={plantDetails._id}>
+            <PlantCard
+              plantName={plantDetails.name}
+              plantDetails={plantDetails.scientificName}
+            />
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/Pages/SignUp.jsx
+++ b/src/Pages/SignUp.jsx
@@ -1,26 +1,24 @@
-import React from "react";
 import Signupform from "../Component/Auth/Signupform";
 import Loader from "../Component/Loader";
 import { useSelector } from "react-redux";
 
 const SignUp = () => {
-  // Selecting the loading state from the Redux store
   const loading = useSelector((state) => state.auth.loading);
 
   return (
-    <div className="relative min-h-screen flex items-center justify-center">
+    <div className="min-h-screen bg-white flex items-center justify-center px-4 py-12">
       {loading ? (
         <Loader />
       ) : (
-        <div className="bg-slate-800/10 m-8 lg:max-w-[40%] border-2 border-green-950 rounded-md p-8 text-left">
-          <h1 className="text-black/85 text-3xl poppins-bold">
-            Join Clean Breath: <br /> Plant for a Healthier Tomorrow!
+        <div className="bg-green-50 border border-green-500 rounded-lg shadow-lg w-full max-w-xl p-8">
+          <h1 className="text-3xl font-bold text-green-800 mb-4 leading-tight">
+            Join Clean Breath
+            <br className="hidden sm:block" /> Plant for a Healthier Tomorrow!
           </h1>
-          <p className="poppins-regular text-black/60">
-            Welcome to Clean Breath! We're on a mission to help you improve air
-            quality by planting the right trees and plants. By signing up, you
-            become part of a community dedicated to creating a cleaner,
-            healthier environment for everyone.
+          <p className="text-gray-700 text-sm mb-6 leading-relaxed">
+            Be part of a greener world! Sign up to explore which plants improve
+            air quality and discover how your green choices create a cleaner,
+            healthier environment.
           </p>
           <Signupform />
         </div>


### PR DESCRIPTION
Hi team 👋

This PR resolves the UI/UX inconsistencies mentioned in issue [#73](https://github.com/chandannekya/Clean-Breath/issues/73), focusing on color contrast, interactivity, and overall visual improvements across key pages of the app.

---

### ✅ Summary of Fixes & Improvements:

#### 1️⃣ Sign In / Sign Up Form Color Contrast
- Improved **text readability** and **contrast** in forms.
- Added **proper hover and focus states** on buttons and input fields.
- Enhanced form structure for a more modern and accessible layout.

Before:
<img width="784" height="785" alt="image" src="https://github.com/user-attachments/assets/34fba492-8605-445d-9894-3ad1a64ecaa1" />

After:
<img width="757" height="693" alt="image" src="https://github.com/user-attachments/assets/b50d8a6c-cdcc-4320-ac23-0fbf8e825789" />


#### 2️⃣ Footer Hover Color Bug
- Fixed link hover color to ensure **sufficient contrast** on light backgrounds.
- Improved footer padding, alignment, and layout consistency.

Before:
<img width="1898" height="252" alt="image" src="https://github.com/user-attachments/assets/a85af163-f30a-4ff0-88b9-35a1c84e2bd1" />

After:
<img width="1900" height="432" alt="image" src="https://github.com/user-attachments/assets/9dde082a-4dc9-41be-b013-de6a7ff52b63" />


#### 3️⃣ FAQ Section Interaction
- Completely **rebuilt the FAQ section from scratch**.
- Now the **entire question div is clickable**, not just the “+” icon.
- Smoother transitions and cleaner expand/collapse logic.

Before:
<img width="1201" height="682" alt="image" src="https://github.com/user-attachments/assets/50330043-3d9a-4c44-9212-777929841aa8" />

After:
<img width="1193" height="700" alt="image" src="https://github.com/user-attachments/assets/f812a0f4-78b9-4805-925f-98b9c4feeb4d" />


#### 4️⃣ Plants Page UI Fixes
- Fixed broken **card UI** and inconsistent **text alignment**.
- Improved **color contrast** and spacing across the layout.

Before:
<img width="458" height="89" alt="image" src="https://github.com/user-attachments/assets/fdfc6103-9bc6-4ef0-b171-8cdc3f079dc9" />

After:
<img width="456" height="81" alt="image" src="https://github.com/user-attachments/assets/54313ece-0123-465f-8cf9-be87ae230d2c" />


---

### 🏷 Please add the following labels in my PR too:
- `gssoc2025`
- `level 2`

Let me know if you'd like any additional changes. Looking forward to your feedback and review! 🚀

Thanks!
