### PR TITLE
Feature: Added "Show/Hide Password" Eye Icon in Signup and Sign-in Forms

### DIFF
--- a/src/Component/Auth/Loginform.jsx
+++ b/src/Component/Auth/Loginform.jsx
@@ -3,12 +3,13 @@ import { toast } from "react-hot-toast";
 import { signin } from "../../service/oprations/authApi";
 import { useNavigate } from "react-router-dom";
 import { useDispatch } from "react-redux";
-
+import { EyeIcon,EyeOffIcon } from "lucide-react";
 const Logingform = () => {
   const [formData, setFormData] = useState({
     email: "",
     password: "",
   });
+  const [showPassword,setShowPassword] = useState(false);
 
   const handleChange = (e) =>
     setFormData({ ...formData, [e.target.name]: e.target.value });
@@ -55,14 +56,22 @@ const Logingform = () => {
         <label className="block text-sm font-medium text-green-800 mb-1">
           Password
         </label>
+        <div className="relative">
         <input
           className="w-full rounded-md p-2 bg-white border border-green-300 input-shadow focus:outline-none focus:ring-2 focus:ring-green-400"
-          type="password"
+          type={showPassword ? "text" : "password"}
           name="password"
           placeholder="••••••••"
           onChange={handleChange}
           value={formData.password}
         />
+          <span
+            onClick={() => setShowPassword((prev) => !prev)}
+            className="absolute inset-y-0 right-3 flex items-center cursor-pointer text-green-600 hover:text-green-800"
+          >
+            {showPassword ? <EyeOffIcon size={20} /> : <EyeIcon size={20} />}
+          </span>
+        </div>
       </div>
 
       <button

--- a/src/Component/Auth/Signupform.jsx
+++ b/src/Component/Auth/Signupform.jsx
@@ -3,6 +3,7 @@ import { toast } from "react-hot-toast";
 import { signUp } from "../../service/oprations/authApi";
 import { useNavigate } from "react-router-dom";
 import { useDispatch } from "react-redux";
+import { EyeIcon,EyeOffIcon } from "lucide-react";
 
 const Signupform = () => {
   const [formData, setFormData] = useState({
@@ -10,6 +11,7 @@ const Signupform = () => {
     username: "",
     password: "",
   });
+  const [showPassword, setShowPassword] = useState(false);
 
   const handleChange = (e) =>
     setFormData({ ...formData, [e.target.name]: e.target.value });
@@ -67,15 +69,24 @@ const Signupform = () => {
         <label className="block text-sm font-medium text-green-800 mb-1">
           Password
         </label>
+        <div className="relative">
         <input
           className="w-full rounded-md p-2 bg-white border border-green-300 input-shadow focus:outline-none focus:ring-2 focus:ring-green-400"
-          type="password"
+          type={showPassword ? "text" : "password"}
           name="password"
           placeholder="••••••••"
           value={formData.password}
           onChange={handleChange}
         />
+          <span
+            onClick={() => setShowPassword((prev) => !prev)}
+            className="absolute inset-y-0 right-3 flex items-center cursor-pointer text-green-600 hover:text-green-800"
+          >
+            {showPassword ? <EyeOffIcon size={20} /> : <EyeIcon size={20} />}
+          </span>
+        </div>
       </div>
+       
 
       <button
         type="submit"


### PR DESCRIPTION
**Description:**
This PR implements a password visibility toggle feature in both the Signup and Sign-in forms.
Added an eye icon that toggles between showing and hiding the password.
-When the password is hidden, the eye icon appears.
-When the password is visible, the eye-off icon appears.
-Updated onClick handler to correctly toggle the input type and icon.
**Issue Linked:**
-Fixes #125  — "Add 'Show/Hide Password' Eye Icon in Signup and Sign in Form"
**How Has This Been Tested?**
-Verified that clicking the icon switches the password field 
-Confirmed the correct icon displays for each state.
-Tested functionality in both Signup and Sign-in forms.
**Screenshots:**
<img width="890" height="737" alt="Screenshot 2025-08-12 224532" src="https://github.com/user-attachments/assets/b7a0795a-cfca-43b4-baae-a5460a0202ac" />
<img width="963" height="571" alt="Screenshot 2025-08-12 224542" src="https://github.com/user-attachments/assets/be332aa2-c120-4492-ac0b-5283c66696bc" />
