### PR TITLE
add Environment Variables section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@
 
 - **Payment Gateway**: Razorpay
 
+## 🔐 Environment Variables
+
+Before running the backend, you need to configure environment variables.
+
+1. Copy the `.env.example` file in the `backend` directory to a new file named `.env`.
+2. Fill in the variables with your own values.
+
+**Variables:**
+- `PORT` — The port number for the backend server (e.g., 5000)
+- `MONGODB_URI` — Your MongoDB connection string
+- `RAZORPAY_KEY_ID` — Your Razorpay API key ID
+- `RAZORPAY_KEY_SECRET` — Your Razorpay API key secret
+- `CLOUDINARY_CLOUD_NAME` — Your Cloudinary cloud name
+- `CLOUDINARY_API_KEY` — Your Cloudinary API key
+- `CLOUDINARY_API_SECRET` — Your Cloudinary API secret
 
 
 ## Installation


### PR DESCRIPTION
Issue Number #87 

Added a dedicated **Environment Variables** section to the README.md, explaining each variable and providing setup instructions.

### Changes
- Added a "🔐 Environment Variables" section after the "Technologies Used" section.
- Listed all required environment variables with brief descriptions.

This improves clarity for new contributors by centralizing environment variable setup instructions in one place, instead of spreading them across the README.